### PR TITLE
Replace IRC reference with Gitter link

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
               <li><a href="https://github.com/OpenTreeMap/OTM2/wiki" target="_blank">Documentation</a></li>
               <li><a href="https://github.com/OpenTreeMap/OTM2/issues" target="_blank">Report bugs on Github</a></li>
               <li><a href="https://groups.google.com/forum/?fromgroups#!forum/opentreemap-user" target="_blank">Mailing List</a></li>
-              <li>IRC at #opentreemap on freenode</li>
+              <li><a href="https://gitter.im/OpenTreeMap/otm-core" target="_blank">Gitter chat room</a></li>
             </ul>
             <p>
               Have the base code but don’t know what to do with it? Interested in developing new features but don’t know how? We can help you implement your own urban forestry inventory application with OpenTreeMap. Our services include:


### PR DESCRIPTION
The development team has switched to using Gitter for community chat.